### PR TITLE
Add rate-limit pauses and registry validation checks to prevent truncated registry from being autogenerated. 

### DIFF
--- a/.github/workflows/regenerate-registry.yaml
+++ b/.github/workflows/regenerate-registry.yaml
@@ -37,6 +37,17 @@ jobs:
       - name: Install project dependencies
         run: uv sync
 
+      - name: Capture previous registry entry count
+        id: prev-count
+        run: |
+          if [ -f linkml_registry.yaml ]; then
+            OLD_COUNT=$(uv run python -c "import yaml,sys; d=yaml.safe_load(open('linkml_registry.yaml')); print(len((d or {}).get('entries') or {}))")
+          else
+            OLD_COUNT=0
+          fi
+          echo "old_count=${OLD_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Previous registry entry count: ${OLD_COUNT}"
+
       - name: Generate LinkML Registry Artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,18 +55,58 @@ jobs:
           mkdir -p docs
           touch docs/.nojekyll
           make gendoc
-          if [ $? -eq 0 ]; then
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add linkml_registry.yaml docs/
-            if ! git diff --cached --quiet; then
-              git commit -m "Regenerate LinkML registry artifacts"
-              git push origin HEAD:main
-            else
-              echo "No changes to commit"
-            fi
-          else
-            echo "'make gendoc' failed to finish successfully"
+
+      - name: Verify new registry is not a regression
+        env:
+          OLD_COUNT: ${{ steps.prev-count.outputs.old_count }}
+          # Hard floor on entry count. Recent baseline is ~200; set conservatively.
+          MIN_EXPECTED: "150"
+          # Fail if new count drops by more than this fraction of the old count.
+          MAX_DROP_FRACTION: "0.15"
+        run: |
+          if [ ! -f linkml_registry.yaml ]; then
+            echo "::error::linkml_registry.yaml was not produced by make gendoc"
+            exit 1
           fi
+          NEW_COUNT=$(uv run python -c "import yaml; d=yaml.safe_load(open('linkml_registry.yaml')); print(len((d or {}).get('entries') or {}))")
+          echo "new_count=${NEW_COUNT}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Registry regeneration"
+            echo ""
+            echo "- Previous entries: ${OLD_COUNT}"
+            echo "- New entries: ${NEW_COUNT}"
+            echo "- Hard floor: ${MIN_EXPECTED}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${NEW_COUNT}" -lt "${MIN_EXPECTED}" ]; then
+            echo "::error::New registry has ${NEW_COUNT} entries (< MIN_EXPECTED=${MIN_EXPECTED}); refusing to publish."
+            exit 1
+          fi
+
+          if [ "${OLD_COUNT}" -gt 0 ]; then
+            # Bash can't do floats; use python for the threshold comparison.
+            REGRESSED=$(python3 -c "import os,sys; o=int(os.environ['OLD_COUNT']); n=int('${NEW_COUNT}'); f=float(os.environ['MAX_DROP_FRACTION']); sys.stdout.write('1' if n < o*(1.0 - f) else '0')")
+            if [ "${REGRESSED}" = "1" ]; then
+              echo "::error::New registry entry count (${NEW_COUNT}) dropped >${MAX_DROP_FRACTION} below previous (${OLD_COUNT}); refusing to publish."
+              exit 1
+            fi
+          fi
+
+          echo "Registry size check passed (${NEW_COUNT} entries)."
+
+      - name: Commit regenerated registry
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add linkml_registry.yaml docs/
+          if ! git diff --cached --quiet; then
+            git commit -m "Regenerate LinkML registry artifacts"
+            git push origin HEAD:main
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Deploy to GitHub Pages
+        run: |
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           uv run mkdocs gh-deploy --force

--- a/linkml_registry.yaml
+++ b/linkml_registry.yaml
@@ -1,8 +1,89 @@
 name: LinkML-Discovery-Registry
 homepage: https://github.com/linkml/linkml-registry
 title: LinkML Registry (GitHub Search Discovery)
-description: LinkML projects discovered via GitHub Search API. Generated on 2026-05-25 11:03:27
+description: LinkML projects discovered via GitHub Search API. Generated on 2026-05-28 10:47:40
 entries:
+  harvard-edge/cs249r_book:
+    title: cs249r_book
+    description: Machine Learning Systems
+    github_repo: https://github.com/harvard-edge/cs249r_book
+    license: NOASSERTION
+    domain: Computer Science
+    status: active
+    topics:
+    - artificial-intelligence
+    - cloud-ml
+    - computer-systems
+    - courseware
+    - deep-learning
+    schema_url: https://harvard-edge.github.io/cs249r_book/
+    contacts: harvard-edge
+    github_stars: 24512
+  monarch-initiative/ontogpt:
+    title: ontogpt
+    description: LLM-based ontological extraction tools, including SPIRES
+    github_repo: https://github.com/monarch-initiative/ontogpt
+    license: BSD-3-Clause
+    domain: Computer Science
+    status: active
+    topics:
+    - ai
+    - chat-gpt
+    - data-modeling
+    - gpt-3
+    - information-extraction
+    schema_url: https://monarch-initiative.github.io/ontogpt/
+    contacts: monarch-initiative
+    github_stars: 890
+  pysemtec/semantic-python-overview:
+    title: semantic-python-overview
+    description: (subjective) overview of projects which are related both to python and semantic technologies (RDF, OWL, Reasoning,
+      ...)
+    github_repo: https://github.com/pysemtec/semantic-python-overview
+    license: CC0-1.0
+    domain: Schema
+    status: active
+    topics:
+    - collection
+    - community-driven
+    - datalog
+    - knowledge-graph
+    - ontology
+    schema_url: https://pysemtec.github.io/semantic-python-overview/
+    contacts: pysemtec
+    github_stars: 550
+  INCATools/ontology-development-kit:
+    title: ontology-development-kit
+    description: Ontology lifecycle management
+    github_repo: https://github.com/INCATools/ontology-development-kit
+    license: BSD-3-Clause
+    domain: Schema
+    status: active
+    topics:
+    - continuous-integration
+    - monarchinitiative
+    - obo
+    - obofoundry
+    - ontology
+    schema_url: http://incatools.github.io/ontology-development-kit/
+    contacts: INCATools
+    github_stars: 334
+  monarch-initiative/mondo:
+    title: mondo
+    description: Mondo Disease Ontology
+    github_repo: https://github.com/monarch-initiative/mondo
+    license: CC-BY-4.0
+    domain: Computer Science
+    status: active
+    topics:
+    - ai4curation
+    - disease
+    - disease-classification
+    - monarchinitiative
+    - mondo
+    schema_url: https://monarch-initiative.github.io/mondo/
+    contacts: monarch-initiative
+    github_stars: 302
   biolink/biolink-model:
     title: biolink-model
     description: Schema and generated objects for biolink data model and upper ontology
@@ -18,7 +99,24 @@ entries:
     - json-api
     schema_url: https://biolink.github.io/biolink-model/
     contacts: biolink
-    github_stars: 241
+    github_stars: 242
+  pydna-group/pydna:
+    title: pydna
+    description: Clone with Python! Data structures for double stranded DNA & simulation of homologous recombination, Gibson
+      assembly, cut & paste cloning.
+    github_repo: https://github.com/pydna-group/pydna
+    license: NOASSERTION
+    domain: Biology
+    status: active
+    topics:
+    - anaconda
+    - assembly-strategies
+    - bioinformatics
+    - biology
+    - biopython
+    schema_url: https://pydna-group.github.io/pydna/
+    contacts: pydna-group
+    github_stars: 226
   mapping-commons/sssom:
     title: sssom
     description: Simple Standard for Sharing Ontology Mappings
@@ -35,6 +133,22 @@ entries:
     schema_url: https://mapping-commons.github.io/sssom/
     contacts: mapping-commons
     github_stars: 201
+  INCATools/ontology-access-kit:
+    title: ontology-access-kit
+    description: 'Ontology Access Kit: A python library and command line application for working with ontologies'
+    github_repo: https://github.com/INCATools/ontology-access-kit
+    license: Apache-2.0
+    domain: Schema
+    status: active
+    topics:
+    - apis
+    - geneontology
+    - monarchinitiative
+    - oaklib
+    - obofoundry
+    schema_url: https://incatools.github.io/ontology-access-kit/
+    contacts: INCATools
+    github_stars: 171
   cidgoh/DataHarmonizer:
     title: DataHarmonizer
     description: A standardized browser-based spreadsheet editor and validator that can be run offline and locally, and which
@@ -54,6 +168,60 @@ entries:
     schema_url: https://cidgoh.github.io/DataHarmonizer/
     contacts: cidgoh
     github_stars: 127
+  IBM/ai-atlas-nexus:
+    title: ai-atlas-nexus
+    description: 'AI Atlas Nexus: tooling to bring together resources related to governance of foundation models.'
+    github_repo: https://github.com/IBM/ai-atlas-nexus
+    license: Apache-2.0
+    domain: Computer Science
+    status: active
+    schema_url: https://ibm.github.io/ai-atlas-nexus/
+    contacts: IBM
+    github_stars: 121
+  oborel/obo-relations:
+    title: obo-relations
+    description: RO is an ontology of relations for use with biological ontologies
+    github_repo: https://github.com/oborel/obo-relations
+    license: NOASSERTION
+    domain: Biology
+    status: active
+    topics:
+    - bfo
+    - knowledge-graph
+    - obo-relations
+    - obofoundry
+    - ontologies
+    schema_url: http://oborel.github.io/obo-relations/
+    contacts: oborel
+    github_stars: 112
+  Knowledge-Graph-Hub/kg-covid-19:
+    title: kg-covid-19
+    description: An instance of KG Hub to produce a knowledge graph for COVID-19 response.
+    github_repo: https://github.com/Knowledge-Graph-Hub/kg-covid-19
+    license: BSD-3-Clause
+    domain: Schema
+    status: active
+    topics:
+    - monarchinitiative
+    schema_url: https://knowledge-graph-hub.github.io/kg-covid-19/
+    contacts: Knowledge-Graph-Hub
+    github_stars: 84
+  EMSL-Computing/CoreMS:
+    title: CoreMS
+    description: CoreMS is a comprehensive mass spectrometry software framework
+    github_repo: https://github.com/EMSL-Computing/CoreMS
+    license: BSD-2-Clause
+    domain: Biology
+    status: active
+    topics:
+    - complex-mixture
+    - data-analysis
+    - dissolved-organic-matter
+    - mass-spectrometry
+    - metabolomics
+    schema_url: https://emsl-computing.github.io/CoreMS/
+    contacts: EMSL-Computing
+    github_stars: 65
   monarch-initiative/koza:
     title: koza
     description: Data transformation framework for LinkML data models
@@ -70,6 +238,38 @@ entries:
     schema_url: https://monarch-initiative.github.io/koza/
     contacts: monarch-initiative
     github_stars: 64
+  INCATools/semantic-sql:
+    title: semantic-sql
+    description: SQL and SQLite builds of OWL ontologies
+    github_repo: https://github.com/INCATools/semantic-sql
+    license: BSD-3-Clause
+    domain: Computer Science
+    status: active
+    topics:
+    - ai4curation
+    - linkml
+    - monarchinitiative
+    - oaklib
+    - obofoundry
+    schema_url: https://incatools.github.io/semantic-sql/
+    contacts: INCATools
+    github_stars: 64
+  GenomicsStandardsConsortium/mixs:
+    title: mixs
+    description: "Minimum Information about any (X) Sequence\u201D (MIxS) specification"
+    github_repo: https://github.com/GenomicsStandardsConsortium/mixs
+    license: CC0-1.0
+    domain: Biology
+    status: active
+    topics:
+    - bioinformatics
+    - contextual-data
+    - genomics
+    - gsc
+    - json-schema
+    schema_url: https://w3id.org/mixs
+    contacts: GenomicsStandardsConsortium
+    github_stars: 63
   mapping-commons/sssom-py:
     title: sssom-py
     description: Python toolkit for SSSOM mapping format
@@ -86,22 +286,31 @@ entries:
     schema_url: https://mapping-commons.github.io/sssom-py/index.html#
     contacts: mapping-commons
     github_stars: 62
-  INCATools/semantic-sql:
-    title: semantic-sql
-    description: SQL and SQLite builds of OWL ontologies
-    github_repo: https://github.com/INCATools/semantic-sql
-    license: BSD-3-Clause
+  berkeleybop/artificial-intelligence-ontology:
+    title: artificial-intelligence-ontology
+    description: An ontology modeling classes and relationships describing deep learning networks, their component layers
+      and activation functions, machine learning methods, as well as AI/ML potential biases.
+    github_repo: https://github.com/berkeleybop/artificial-intelligence-ontology
     domain: Computer Science
     status: active
     topics:
-    - ai4curation
-    - linkml
-    - monarchinitiative
-    - oaklib
-    - obofoundry
-    schema_url: https://incatools.github.io/semantic-sql/
-    contacts: INCATools
-    github_stars: 61
+    - artificial-intelligence
+    - deep-learning
+    - ontology
+    - vocabulary
+    schema_url: https://berkeleybop.github.io/artificial-intelligence-ontology/
+    contacts: berkeleybop
+    github_stars: 49
+  margo/specification:
+    title: specification
+    description: Margo Specification
+    github_repo: https://github.com/margo/specification
+    license: NOASSERTION
+    domain: Schema
+    status: active
+    schema_url: https://margo.github.io/specification/
+    contacts: margo
+    github_stars: 48
   microbiomedata/nmdc-schema:
     title: nmdc-schema
     description: National Microbiome Data Collaborative (NMDC) unified data model
@@ -118,6 +327,20 @@ entries:
     schema_url: https://microbiomedata.github.io/nmdc-schema/
     contacts: microbiomedata
     github_stars: 46
+  everycure-org/matrix:
+    title: matrix
+    github_repo: https://github.com/everycure-org/matrix
+    license: Apache-2.0
+    domain: Biology
+    status: active
+    topics:
+    - bioinformatics
+    - medical
+    - repurposing
+    - research
+    schema_url: https://docs.dev.everycure.org/
+    contacts: everycure-org
+    github_stars: 44
   cmungall/semantic-llama:
     title: semantic-llama
     description: A knowledge extraction tool that uses a large language model to extract semantic information from text
@@ -134,6 +357,65 @@ entries:
     schema_url: https://cmungall.github.io/semantic-llama/
     contacts: cmungall
     github_stars: 30
+  cdisc-org/COSMoS:
+    title: COSMoS
+    description: CDISC Conceptual and Operational Standards Metadata Services (COSMoS)
+    github_repo: https://github.com/cdisc-org/COSMoS
+    license: MIT
+    domain: Schema
+    status: active
+    topics:
+    - cosmos
+    schema_url: https://cdisc-org.github.io/COSMoS/
+    contacts: cdisc-org
+    github_stars: 26
+  monarch-initiative/dismech:
+    title: dismech
+    description: Disease Mechanisms KB
+    github_repo: https://github.com/monarch-initiative/dismech
+    license: BSD-3-Clause
+    domain: Computer Science
+    status: active
+    topics:
+    - agentic-ai
+    - disease-mechanisms
+    - kozahub-ingest
+    - linkml
+    - monarchinitiative
+    schema_url: https://monarch-initiative.github.io/dismech
+    contacts: monarch-initiative
+    github_stars: 26
+  Knowledge-Graph-Hub/kg-registry:
+    title: kg-registry
+    description: A registry of Knowledge Graphs, their data sources, and the ways they fit together.
+    github_repo: https://github.com/Knowledge-Graph-Hub/kg-registry
+    license: NOASSERTION
+    domain: Schema
+    status: active
+    topics:
+    - graph
+    - kg
+    - kg-hub
+    - knowledge
+    - knowledge-graph
+    schema_url: https://knowledge-graph-hub.github.io/kg-registry/
+    contacts: Knowledge-Graph-Hub
+    github_stars: 26
+  NeurodataWithoutBorders/nwb_hackathons:
+    title: nwb_hackathons
+    description: Repository for collecting materials from nwb hackathons
+    github_repo: https://github.com/NeurodataWithoutBorders/nwb_hackathons
+    domain: Neuroscience
+    status: active
+    topics:
+    - dataformat
+    - hackathon
+    - hdf
+    - hdf5
+    - international-conference
+    schema_url: https://neurodatawithoutborders.github.io/nwb_hackathons
+    contacts: NeurodataWithoutBorders
+    github_stars: 25
   monarch-initiative/monarch-ingest:
     title: monarch-ingest
     description: Data ingest application for Monarch Initiative knowledge graph using Koza
@@ -181,6 +463,30 @@ entries:
     - rdf
     schema_url: https://w3id.org/kgcl/
     contacts: INCATools
+    github_stars: 23
+  Colectica/cogs:
+    title: cogs
+    description: Convention-based Ontology Generation System
+    github_repo: https://github.com/Colectica/cogs
+    license: MIT
+    domain: Infrastructure
+    status: active
+    topics:
+    - csharp
+    - metadata
+    - ontology
+    - ontology-generation
+    schema_url: https://colectica.github.io/cogs/
+    contacts: Colectica
+    github_stars: 22
+  incf-nidash/PyNIDM:
+    title: PyNIDM
+    github_repo: https://github.com/incf-nidash/PyNIDM
+    license: NOASSERTION
+    domain: Schema
+    status: active
+    schema_url: https://incf-nidash.github.io/PyNIDM/
+    contacts: incf-nidash
     github_stars: 22
   py-typedlogic/py-typedlogic:
     title: py-typedlogic
@@ -198,6 +504,15 @@ entries:
     schema_url: https://py-typedlogic.github.io
     contacts: py-typedlogic
     github_stars: 21
+  bilayer-containers/bilayers:
+    title: bilayers
+    github_repo: https://github.com/bilayer-containers/bilayers
+    license: NOASSERTION
+    domain: Schema
+    status: active
+    schema_url: https://bilayer-containers.github.io/bilayers/
+    contacts: bilayer-containers
+    github_stars: 20
   INCATools/kgcl-rdflib:
     title: kgcl-rdflib
     description: Tools for working with KGCL
@@ -227,6 +542,32 @@ entries:
     schema_url: https://cancerdhc.github.io/ccdhmodel/
     contacts: cancerDHC
     github_stars: 18
+  loinc/comp-loinc:
+    title: comp-loinc
+    description: Computational LOINC in OWL.
+    github_repo: https://github.com/loinc/comp-loinc
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://loinc.github.io/comp-loinc/
+    contacts: loinc
+    github_stars: 18
+  ddialliance/ddimodel:
+    title: ddimodel
+    description: Model for DDI Lifecycle
+    github_repo: https://github.com/ddialliance/ddimodel
+    license: CC-BY-4.0
+    domain: Schema
+    status: active
+    topics:
+    - ddi
+    - metadata
+    - rdf
+    - standard
+    - xsd-schema
+    schema_url: https://ddialliance.github.io/ddimodel/
+    contacts: ddialliance
+    github_stars: 16
   ghga-de/ghga-metadata-schema:
     title: ghga-metadata-schema
     description: Metadata schema for the German Human Genome-Phenome Archive (GHGA)
@@ -257,6 +598,29 @@ entries:
     schema_url: http://monarch-initiative.github.io/monochrom/
     contacts: monarch-initiative
     github_stars: 16
+  swiss/political-affairs-ech-group:
+    title: political-affairs-ech-group
+    description: The working repository to develop standards for the swiss political system.
+    github_repo: https://github.com/swiss/political-affairs-ech-group
+    domain: Computer Science
+    status: active
+    schema_url: https://swiss.github.io/political-affairs-ech-group/
+    contacts: swiss
+    github_stars: 16
+  bridge2ai/b2ai-standards-registry:
+    title: b2ai-standards-registry
+    description: Bridge2AI Standards Registry data models, API specification, and other documentation.
+    github_repo: https://github.com/bridge2ai/b2ai-standards-registry
+    license: MIT
+    domain: Computer Science
+    status: active
+    topics:
+    - bridge2ai
+    - standards
+    - standards-registry
+    schema_url: https://bridge2ai.github.io/b2ai-standards-registry/
+    contacts: bridge2ai
+    github_stars: 15
   monarch-initiative/namo:
     title: namo
     github_repo: https://github.com/monarch-initiative/namo
@@ -289,6 +653,70 @@ entries:
     schema_url: https://nfdi-de.github.io/chem-dcat-ap/
     contacts: nfdi-de
     github_stars: 14
+  reusabledata/reusabledata:
+    title: reusabledata
+    description: The home repository for the (Re)usable Data Project.
+    github_repo: https://github.com/reusabledata/reusabledata
+    license: BSD-3-Clause
+    domain: Schema
+    status: active
+    schema_url: https://reusabledata.github.io/reusabledata/
+    contacts: reusabledata
+    github_stars: 14
+  co-cddo/ukgov-metadata-exchange-model:
+    title: ukgov-metadata-exchange-model
+    description: A metadata model for describing data assets for exchanging between UK government organisations.
+    github_repo: https://github.com/co-cddo/ukgov-metadata-exchange-model
+    license: NOASSERTION
+    domain: Computer Science
+    status: active
+    topics:
+    - dataset
+    - dcat
+    - fair-data
+    schema_url: https://co-cddo.github.io/ukgov-metadata-exchange-model/
+    contacts: co-cddo
+    github_stars: 14
+  tcr/markdown-corpus:
+    title: markdown-corpus
+    description: Many markdown files taken from around github
+    github_repo: https://github.com/tcr/markdown-corpus
+    domain: Schema
+    status: maintenance
+    schema_url: https://tcr.github.io/markdown-corpus/
+    contacts: tcr
+    github_stars: 13
+  alliance-genome/agr_curation_schema:
+    title: agr_curation_schema
+    description: Schema repository for the Alliance of Genome Resources persistent data store
+    github_repo: https://github.com/alliance-genome/agr_curation_schema
+    license: MIT
+    domain: Computer Science
+    status: active
+    topics:
+    - alliance-curation
+    - alliance-of-genome-resources
+    - linkml
+    schema_url: https://alliance-genome.github.io/agr_curation_schema/
+    contacts: alliance-genome
+    github_stars: 12
+  tum-ens/InfDB:
+    title: InfDB
+    description: InfDB (Energy and Infrastructure Database) provides a modular and easy-to-configure open-source data and
+      tool infrastructure equipped with essential services, designed to minimize the effort required for data management.
+    github_repo: https://github.com/tum-ens/InfDB
+    license: Apache-2.0
+    domain: Computer Science
+    status: active
+    topics:
+    - data-science
+    - database
+    - energy
+    - kwp
+    - modelling
+    schema_url: https://tum-ens.github.io/InfDB/
+    contacts: tum-ens
+    github_stars: 12
   cmungall/json-flattener:
     title: json-flattener
     description: Python library for denormalizing nested dicts or json objects to tables and back
@@ -303,6 +731,47 @@ entries:
     - pandas
     schema_url: https://cmungall.github.io/json-flattener/
     contacts: cmungall
+    github_stars: 12
+  isamplesorg/metadata:
+    title: metadata
+    description: Collation of metadata examples and notes for the project
+    github_repo: https://github.com/isamplesorg/metadata
+    domain: Computer Science
+    status: active
+    topics:
+    - linkml
+    - metadata
+    - physical-specimen
+    schema_url: https://isamplesorg.github.io/metadata/
+    contacts: isamplesorg
+    github_stars: 12
+  monarch-initiative/mondo-ingest:
+    title: mondo-ingest
+    description: Coordinating the mondo-ingest with external sources
+    github_repo: https://github.com/monarch-initiative/mondo-ingest
+    domain: Schema
+    status: active
+    topics:
+    - monarchinitiative
+    schema_url: https://monarch-initiative.github.io/mondo-ingest/
+    contacts: monarch-initiative
+    github_stars: 12
+  MaastrichtU-IDS/translator-openpredict:
+    title: translator-openpredict
+    description: "\U0001F52E\U0001F40D A package to help serve predictions of biomedical concepts associations as Translator\
+      \ Reasoner API"
+    github_repo: https://github.com/MaastrichtU-IDS/translator-openpredict
+    license: MIT
+    domain: Biology
+    status: inactive
+    topics:
+    - biomedical-concepts-associations
+    - openapi
+    - predict
+    - translator-api
+    - trapi
+    schema_url: https://maastrichtu-ids.github.io/translator-openpredict/
+    contacts: MaastrichtU-IDS
     github_stars: 12
   nfdi-de/dcat-ap-plus:
     title: dcat-ap-plus
@@ -392,6 +861,27 @@ entries:
     schema_url: https://culturebotai.github.io/CultureMech/
     contacts: CultureBotAI
     github_stars: 9
+  AltiumDeveloper/cdm:
+    title: cdm
+    description: Altium Common Data Model
+    github_repo: https://github.com/AltiumDeveloper/cdm
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://altiumdeveloper.github.io/cdm
+    contacts: AltiumDeveloper
+    github_stars: 8
+  TeMeta/define-json:
+    title: define-json
+    description: A metadata exchange model for Data Contracts and specs. Simplified successor to Define-XML that links explicitly
+      to CDISC USDM, CDISC ODM, HL7 FHIR, OMOP CDM
+    github_repo: https://github.com/TeMeta/define-json
+    license: MIT
+    domain: Computer Science
+    status: active
+    schema_url: https://temeta.github.io/define-json/
+    contacts: TeMeta
+    github_stars: 8
   vladistan/linkml-qudt:
     title: linkml-qudt
     description: Conversion of QUDT ontology to LinkML
@@ -408,6 +898,44 @@ entries:
     schema_url: https://vladistan.github.io/linkml-qudt/
     contacts: vladistan
     github_stars: 8
+  monarch-initiative/monarch-documentation:
+    title: monarch-documentation
+    description: Technical documentation for all Monarch applications, packages, services and related projects.
+    github_repo: https://github.com/monarch-initiative/monarch-documentation
+    license: GPL-3.0
+    domain: Schema
+    status: active
+    schema_url: https://monarch-initiative.github.io/monarch-documentation/
+    contacts: monarch-initiative
+    github_stars: 8
+  sensein/structsense:
+    title: structsense
+    github_repo: https://github.com/sensein/structsense
+    license: Apache-2.0
+    domain: Schema
+    status: active
+    schema_url: https://sensein.github.io/structsense/
+    contacts: sensein
+    github_stars: 8
+  w3c/wot-thing-description-toolchain-tmp:
+    title: wot-thing-description-toolchain-tmp
+    description: work area for WoT Thing Description toolchain
+    github_repo: https://github.com/w3c/wot-thing-description-toolchain-tmp
+    domain: Computer Science
+    status: active
+    schema_url: https://w3c.github.io/wot-thing-description-toolchain-tmp/
+    contacts: w3c
+    github_stars: 8
+  chanzuckerberg/cryoet-data-portal-backend:
+    title: cryoet-data-portal-backend
+    description: CryoET Data Portal API server & ingestion scripts
+    github_repo: https://github.com/chanzuckerberg/cryoet-data-portal-backend
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://chanzuckerberg.github.io/cryoet-data-portal-backend/
+    contacts: chanzuckerberg
+    github_stars: 7
   biodatamodels/gff-schema:
     title: gff-schema
     description: LinkML schema for GFF3, the Genome Feature Format
@@ -422,6 +950,20 @@ entries:
     - linkml
     schema_url: https://biodatamodels.github.io/gff-schema/
     contacts: biodatamodels
+    github_stars: 7
+  microbiomedata/nmdc-runtime:
+    title: nmdc-runtime
+    description: Runtime system for NMDC data management and orchestration
+    github_repo: https://github.com/microbiomedata/nmdc-runtime
+    license: NOASSERTION
+    domain: Biology
+    status: active
+    topics:
+    - microbiomedata
+    - nmdc
+    - workflow
+    schema_url: https://microbiomedata.github.io/nmdc-runtime/
+    contacts: microbiomedata
     github_stars: 7
   microbiomedata/sample-annotator:
     title: sample-annotator
@@ -460,6 +1002,17 @@ entries:
     schema_url: https://sepio-framework.github.io/sepio-linkml/
     contacts: sepio-framework
     github_stars: 7
+  PNNL-CompBio/srpAnalytics:
+    title: srpAnalytics
+    description: This repository contains the code necessary to process any new data for the Superfund Research Program Analytics
+      Portal.
+    github_repo: https://github.com/PNNL-CompBio/srpAnalytics
+    license: NOASSERTION
+    domain: Computer Science
+    status: active
+    schema_url: https://pnnl-compbio.github.io/srpAnalytics/
+    contacts: PNNL-CompBio
+    github_stars: 7
   bridge2ai/data-sheets-schema:
     title: data-sheets-schema
     description: Datasheets for Datasets, as LinkML Schema
@@ -470,6 +1023,57 @@ entries:
     schema_url: https://bridge2ai.github.io/data-sheets-schema/
     contacts: bridge2ai
     github_stars: 6
+  alabarga/linkml-omop-tutorial:
+    title: linkml-omop-tutorial
+    github_repo: https://github.com/alabarga/linkml-omop-tutorial
+    domain: Computer Science
+    status: active
+    schema_url: https://alabarga.github.io/linkml-omop-tutorial/
+    contacts: alabarga
+    github_stars: 6
+  cmdoret/mtg_ontology:
+    title: mtg_ontology
+    description: An ontology describing cards in Magic The Gathering.
+    github_repo: https://github.com/cmdoret/mtg_ontology
+    license: GPL-3.0
+    domain: Computer Science
+    status: active
+    topics:
+    - linkml
+    - mtg
+    - ontology
+    - rdf
+    schema_url: https://cmdoret.github.io/mtg_ontology/
+    contacts: cmdoret
+    github_stars: 6
+  contextualizer-ai/cyberian:
+    title: cyberian
+    description: A Python CLI wrapper for running AI coder agents (claude code, gemini-cli, etc)
+    github_repo: https://github.com/contextualizer-ai/cyberian
+    license: BSD-3-Clause
+    domain: Computer Science
+    status: active
+    topics:
+    - ai4curation
+    - monarchinitiative
+    schema_url: https://contextualizer-ai.github.io/cyberian
+    contacts: contextualizer-ai
+    github_stars: 5
+  WolfgangFahl/dcm:
+    title: dcm
+    description: dynamic competence map
+    github_repo: https://github.com/WolfgangFahl/dcm
+    license: Apache-2.0
+    domain: Schema
+    status: active
+    topics:
+    - competence-management
+    - competences
+    - nicegui
+    - skills-assessment
+    schema_url: https://wolfgangfahl.github.io/dcm/
+    contacts: WolfgangFahl
+    github_stars: 5
   gouttegd/linkml-java:
     title: linkml-java
     description: LinkML runtime library for Java
@@ -482,6 +1086,21 @@ entries:
     - semantic-web
     schema_url: https://gouttegd.github.io/linkml-java/
     contacts: gouttegd
+    github_stars: 5
+  cmungall/mianct-schema:
+    title: mianct-schema
+    description: Minimal Information About a New Cell Type
+    github_repo: https://github.com/cmungall/mianct-schema
+    domain: Computer Science
+    status: active
+    topics:
+    - anatomy
+    - cell-ontology
+    - cell-types
+    - checklist
+    - json-schema
+    schema_url: https://cmungall.github.io/mianct-schema/
+    contacts: cmungall
     github_stars: 5
   bridge2ai/model-card-schema:
     title: model-card-schema
@@ -499,6 +1118,16 @@ entries:
     schema_url: https://bridge2ai.github.io/model-card-schema/
     contacts: bridge2ai
     github_stars: 5
+  biodatamodels/obograph:
+    title: obograph
+    github_repo: https://github.com/biodatamodels/obograph
+    domain: Computer Science
+    status: active
+    topics:
+    - linkml
+    schema_url: https://biodatamodels.github.io/obograph/
+    contacts: biodatamodels
+    github_stars: 5
   nfdi4cat/pid4cat-model:
     title: pid4cat-model
     description: Handle-based PIDs with a rich LinkML metadata model for resources in catalysis (PID4Cat)
@@ -514,6 +1143,44 @@ entries:
     schema_url: https://nfdi4cat.github.io/pid4cat-model/
     contacts: nfdi4cat
     github_stars: 5
+  prefixcommons/prefixcommons-py:
+    title: prefixcommons-py
+    description: Prefix commons python utlities
+    github_repo: https://github.com/prefixcommons/prefixcommons-py
+    license: BSD-3-Clause
+    domain: Schema
+    status: maintenance
+    schema_url: https://prefixcommons.github.io/prefixcommons-py/
+    contacts: prefixcommons
+    github_stars: 5
+  regen-network/regen-data-standards:
+    title: regen-data-standards
+    github_repo: https://github.com/regen-network/regen-data-standards
+    domain: Schema
+    status: active
+    schema_url: https://regen-network.github.io/regen-data-standards/
+    contacts: regen-network
+    github_stars: 5
+  timsbiomed/TermCI-model:
+    title: TermCI-model
+    description: The Terminology Code Index Entry model
+    github_repo: https://github.com/timsbiomed/TermCI-model
+    domain: Computer Science
+    status: active
+    topics:
+    - linkml
+    schema_url: https://timsbiomed.github.io/TermCI-model/
+    contacts: timsbiomed
+    github_stars: 5
+  monarch-initiative/cde-harmonization:
+    title: cde-harmonization
+    description: Initial private repo for P1 CDE harmonization
+    github_repo: https://github.com/monarch-initiative/cde-harmonization
+    domain: Schema
+    status: active
+    schema_url: https://monarch-initiative.github.io/cde-harmonization/
+    contacts: monarch-initiative
+    github_stars: 4
   Netbeheer-Nederland/cim-to-linkml:
     title: cim-to-linkml
     description: Generates LinkML schemas for packages in the CIM information model.
@@ -524,6 +1191,38 @@ entries:
     - cim
     schema_url: https://netbeheer-nederland.github.io/cim-to-linkml/
     contacts: Netbeheer-Nederland
+    github_stars: 4
+  TIBHannover/ConfIDent_schema:
+    title: ConfIDent_schema
+    description: The data schema for the ConfIDent project.
+    github_repo: https://github.com/TIBHannover/ConfIDent_schema
+    license: CC-BY-4.0
+    domain: Computer Science
+    status: maintenance
+    topics:
+    - code4lib
+    - linkml-schema
+    - metadata
+    schema_url: https://tibhannover.github.io/ConfIDent_schema/
+    contacts: TIBHannover
+    github_stars: 4
+  chanzuckerberg/czid-platformics:
+    title: czid-platformics
+    github_repo: https://github.com/chanzuckerberg/czid-platformics
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://chanzuckerberg.github.io/czid-platformics/
+    contacts: chanzuckerberg
+    github_stars: 4
+  saved-models/data-utilities:
+    title: data-utilities
+    description: SAVED project - data processing tools for fish farms
+    github_repo: https://github.com/saved-models/data-utilities
+    domain: Schema
+    status: inactive
+    schema_url: https://saved-models.github.io/data-utilities/
+    contacts: saved-models
     github_stars: 4
   Netbeheer-Nederland/gen-linkml-profile:
     title: gen-linkml-profile
@@ -560,6 +1259,20 @@ entries:
     schema_url: https://fair-mi.github.io/miiid-schema/
     contacts: FAIR-MI
     github_stars: 4
+  cmungall/mixs-source:
+    title: mixs-source
+    github_repo: https://github.com/cmungall/mixs-source
+    domain: Biology
+    status: active
+    topics:
+    - genomicsstandards
+    - gsc
+    - linkml
+    - microbiome
+    - microniomedata
+    schema_url: https://cmungall.github.io/mixs-source/
+    contacts: cmungall
+    github_stars: 4
   p2p-ld/nwb-linkml:
     title: nwb-linkml
     description: Translating NWB schema language to linkml
@@ -569,6 +1282,31 @@ entries:
     status: inactive
     schema_url: https://nwb-linkml.readthedocs.io
     contacts: p2p-ld
+    github_stars: 4
+  OpenCloning/OpenCloning_LinkML:
+    title: OpenCloning_LinkML
+    description: A LinkML data model for OpenCloning
+    github_repo: https://github.com/OpenCloning/OpenCloning_LinkML
+    license: MIT
+    domain: Computer Science
+    status: active
+    schema_url: https://opencloning.github.io/OpenCloning_LinkML/
+    contacts: OpenCloning
+    github_stars: 4
+  NCATSTranslator/translator-ingests:
+    title: translator-ingests
+    description: NCATS Biomedical Data Translator Data INGest and Operations WG consolidated data ingest pipeline project.
+    github_repo: https://github.com/NCATSTranslator/translator-ingests
+    license: MIT
+    domain: Biology
+    status: active
+    topics:
+    - biolink
+    - data
+    - knowledge-graph
+    - translator
+    schema_url: https://ncatstranslator.github.io/translator-ingests/
+    contacts: NCATSTranslator
     github_stars: 4
   ber-data/bertron-schema:
     title: bertron-schema
@@ -580,6 +1318,30 @@ entries:
     schema_url: https://ber-data.github.io/bertron-schema/
     contacts: ber-data
     github_stars: 3
+  cmungall/data-manifesto:
+    title: data-manifesto
+    description: semantic modeling of data manifests
+    github_repo: https://github.com/cmungall/data-manifesto
+    domain: Computer Science
+    status: active
+    topics:
+    - data-standards
+    - filesystems
+    - hcls-dataset-description
+    - linked-data
+    - linkml
+    schema_url: https://cmungall.github.io/data-manifesto/
+    contacts: cmungall
+    github_stars: 3
+  Knowledge-Graph-Hub/eco-kg:
+    title: eco-kg
+    github_repo: https://github.com/Knowledge-Graph-Hub/eco-kg
+    license: BSD-3-Clause
+    domain: Schema
+    status: inactive
+    schema_url: https://knowledge-graph-hub.github.io/eco-kg/
+    contacts: Knowledge-Graph-Hub
+    github_stars: 3
   include-dcc/include-linkml:
     title: include-linkml
     description: LinkML Schema for INCLUDE DCC
@@ -589,6 +1351,15 @@ entries:
     status: active
     schema_url: https://include-dcc.github.io/include-linkml/
     contacts: include-dcc
+    github_stars: 3
+  MrBearWithHisSword/KGQA-COVID:
+    title: KGQA-COVID
+    github_repo: https://github.com/MrBearWithHisSword/KGQA-COVID
+    license: BSD-3-Clause
+    domain: Schema
+    status: inactive
+    schema_url: https://mrbearwithhissword.github.io/KGQA-COVID/
+    contacts: MrBearWithHisSword
     github_stars: 3
   EHS-Data-Standards/linkml-aop:
     title: linkml-aop
@@ -600,15 +1371,30 @@ entries:
     schema_url: https://ehs-data-standards.github.io/linkml-aop/
     contacts: EHS-Data-Standards
     github_stars: 3
-  OpenCloning/OpenCloning_LinkML:
-    title: OpenCloning_LinkML
-    description: A LinkML data model for OpenCloning
-    github_repo: https://github.com/OpenCloning/OpenCloning_LinkML
-    license: MIT
-    domain: Computer Science
+  brain-bican/models:
+    title: models
+    description: BICAN data models
+    github_repo: https://github.com/brain-bican/models
+    domain: Schema
     status: active
-    schema_url: https://opencloning.github.io/OpenCloning_LinkML/
-    contacts: OpenCloning
+    schema_url: https://brain-bican.github.io/models/
+    contacts: brain-bican
+    github_stars: 3
+  monarch-initiative/monarch-project-copier:
+    title: monarch-project-copier
+    description: New template for monarch repos, replaces old cookiecutter
+    github_repo: https://github.com/monarch-initiative/monarch-project-copier
+    license: MIT
+    domain: Schema
+    status: active
+    topics:
+    - best-practices
+    - cookiecutter
+    - copier
+    - monarchinitiative
+    - template
+    schema_url: https://monarch-initiative.github.io/monarch-project-copier/
+    contacts: monarch-initiative
     github_stars: 3
   adhollander/PPODLinkML:
     title: PPODLinkML
@@ -620,6 +1406,653 @@ entries:
     schema_url: https://adhollander.github.io/PPODLinkML/
     contacts: adhollander
     github_stars: 3
+  microbiomedata/refscan:
+    title: refscan
+    description: Command-line program that scans NMDC database for referential integrity violations
+    github_repo: https://github.com/microbiomedata/refscan
+    license: NOASSERTION
+    domain: Computer Science
+    status: active
+    topics:
+    - linkml
+    - mongodb
+    - referential-integrity
+    schema_url: https://microbiomedata.github.io/refscan/
+    contacts: microbiomedata
+    github_stars: 3
+  bridge2ai/standards-schemas:
+    title: standards-schemas
+    description: Data schema for Bridge2AI Standards.
+    github_repo: https://github.com/bridge2ai/standards-schemas
+    license: MIT
+    domain: Computer Science
+    status: active
+    schema_url: https://bridge2ai.github.io/standards-schemas/
+    contacts: bridge2ai
+    github_stars: 3
+  airr-knowledge/ak-schema:
+    title: ak-schema
+    description: AIRR Knowledge Schema
+    github_repo: https://github.com/airr-knowledge/ak-schema
+    license: GPL-3.0
+    domain: Computer Science
+    status: active
+    schema_url: https://airr-knowledge.github.io/ak-schema/
+    contacts: airr-knowledge
+    github_stars: 2
+  hsolbrig/BDP-Ontology:
+    title: BDP-Ontology
+    github_repo: https://github.com/hsolbrig/BDP-Ontology
+    license: CC0-1.0
+    domain: Schema
+    status: inactive
+    schema_url: https://hsolbrig.github.io/BDP-Ontology/
+    contacts: hsolbrig
+    github_stars: 2
+  biobricks-ai/biobricks-schema:
+    title: biobricks-schema
+    description: BioBricks data dictionary schema
+    github_repo: https://github.com/biobricks-ai/biobricks-schema
+    license: MIT
+    domain: Biology
+    status: active
+    topics:
+    - linkml
+    schema_url: https://biobricks-ai.github.io/biobricks-schema/
+    contacts: biobricks-ai
+    github_stars: 2
+  AV-EFI/collections2efi:
+    title: collections2efi
+    description: Code used at Stiftung Deutsche Kinemathek to register AVefi compliant PIDs for collections on record in their
+      local Adlib database
+    github_repo: https://github.com/AV-EFI/collections2efi
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://av-efi.github.io/collections2efi/
+    contacts: AV-EFI
+    github_stars: 2
+  kbase/data-lakehouse-ingest:
+    title: data-lakehouse-ingest
+    description: Data Lakehouse Ingest
+    github_repo: https://github.com/kbase/data-lakehouse-ingest
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://kbase.github.io/data-lakehouse-ingest/
+    contacts: kbase
+    github_stars: 2
+  monarch-initiative/dragon-ai-cookiecutter:
+    title: dragon-ai-cookiecutter
+    description: Cookiecutter for DRAGON-AI projects
+    github_repo: https://github.com/monarch-initiative/dragon-ai-cookiecutter
+    license: CC0-1.0
+    domain: Computer Science
+    status: inactive
+    schema_url: https://monarch-initiative.github.io/dragon-ai-cookiecutter/
+    contacts: monarch-initiative
+    github_stars: 2
+  NCATSTranslator/Explanatory-Agent:
+    title: Explanatory-Agent
+    github_repo: https://github.com/NCATSTranslator/Explanatory-Agent
+    domain: Schema
+    status: inactive
+    schema_url: https://ncatstranslator.github.io/Explanatory-Agent/
+    contacts: NCATSTranslator
+    github_stars: 2
+  microbiomedata/external-metadata-awareness:
+    title: external-metadata-awareness
+    description: MongoDB + Parquet analytics for NCBI BioSample/BioProject/SRA and NMDC submission-portal metadata. Environmental
+      triad annotation, harmonized-attribute counts, measurement discovery, value-set voting sheets.
+    github_repo: https://github.com/microbiomedata/external-metadata-awareness
+    domain: Biology
+    status: active
+    schema_url: https://microbiomedata.github.io/external-metadata-awareness/
+    contacts: microbiomedata
+    github_stars: 2
+  slabstech/gaganyatri.in:
+    title: gaganyatri.in
+    description: Gaganyatri - Space Operations for Mars Transfer
+    github_repo: https://github.com/slabstech/gaganyatri.in
+    license: MIT
+    domain: Schema
+    status: maintenance
+    topics:
+    - gaganyaan
+    - hacktoberfest
+    - spacex
+    schema_url: https://slabstech.github.io/gaganyatri.in/
+    contacts: slabstech
+    github_stars: 2
+  ncihtan/htan2-data-model:
+    title: htan2-data-model
+    description: Data Model for HTAN Phase 2
+    github_repo: https://github.com/ncihtan/htan2-data-model
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://ncihtan.github.io/htan2-data-model/
+    contacts: ncihtan
+    github_stars: 2
+  German-BioImaging/idr_metadata_model:
+    title: idr_metadata_model
+    github_repo: https://github.com/German-BioImaging/idr_metadata_model
+    license: Apache-2.0
+    domain: Schema
+    status: active
+    schema_url: https://german-bioimaging.github.io/idr_metadata_model/
+    contacts: German-BioImaging
+    github_stars: 2
+  biolink/ingest-metadata:
+    title: ingest-metadata
+    github_repo: https://github.com/biolink/ingest-metadata
+    license: MIT
+    domain: Schema
+    status: maintenance
+    schema_url: https://biolink.github.io/ingest-metadata
+    contacts: biolink
+    github_stars: 2
+  genomewalker/linkml-toolkit:
+    title: linkml-toolkit
+    github_repo: https://github.com/genomewalker/linkml-toolkit
+    license: MIT
+    domain: Computer Science
+    status: active
+    schema_url: https://genomewalker.github.io/linkml-toolkit/
+    contacts: genomewalker
+    github_stars: 2
+  meaningfy-ws/mapping-suite-sdk:
+    title: mapping-suite-sdk
+    description: SDK designed to standardize and simplify the handling of packages that contain transformation rules and related
+      artefacts for mapping data to RDF (RDF Mapping Language).
+    github_repo: https://github.com/meaningfy-ws/mapping-suite-sdk
+    license: Apache-2.0
+    domain: Computer Science
+    status: active
+    topics:
+    - mapping-suite
+    - sdk
+    schema_url: https://mapping-suite-sdk.readthedocs.io
+    contacts: meaningfy-ws
+    github_stars: 2
+  echemdb/metadata-schema:
+    title: metadata-schema
+    description: Metadata schema describing electrochemical data
+    github_repo: https://github.com/echemdb/metadata-schema
+    license: GPL-3.0
+    domain: Chemistry
+    status: active
+    topics:
+    - electrochemistry
+    - json-schema
+    - metadata
+    - schema
+    schema_url: https://echemdb.github.io/metadata-schema/
+    contacts: echemdb
+    github_stars: 2
+  matentzn/monarch-provenance:
+    title: monarch-provenance
+    github_repo: https://github.com/matentzn/monarch-provenance
+    license: BSD-3-Clause
+    domain: Schema
+    status: maintenance
+    schema_url: https://matentzn.github.io/monarch-provenance/
+    contacts: matentzn
+    github_stars: 2
+  StroemPhi/NMRspec:
+    title: NMRspec
+    description: Prototype to semantify NMR spectroscopy research data
+    github_repo: https://github.com/StroemPhi/NMRspec
+    license: MIT
+    domain: Computer Science
+    status: active
+    topics:
+    - json-ld
+    - knowledge-graph
+    - linkml
+    - rdf
+    schema_url: https://stroemphi.github.io/NMRspec/
+    contacts: StroemPhi
+    github_stars: 2
+  souzadevinicius/phenio-toolkit:
+    title: phenio-toolkit
+    github_repo: https://github.com/souzadevinicius/phenio-toolkit
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://souzadevinicius.github.io/phenio-toolkit/
+    contacts: souzadevinicius
+    github_stars: 2
+  anvilproject/acr-harmonized-data-model:
+    title: acr-harmonized-data-model
+    description: ACR Data Model
+    github_repo: https://github.com/anvilproject/acr-harmonized-data-model
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: http://anvilproject.github.io/acr-harmonized-data-model/
+    contacts: anvilproject
+    github_stars: 1
+  gingin77/aopwiki_emod_web_app:
+    title: aopwiki_emod_web_app
+    description: New AOP-Wiki EMOD application, starting from the v2.7 data model, with some refactors and expansions to include
+      EMOD 2.0 elements
+    github_repo: https://github.com/gingin77/aopwiki_emod_web_app
+    domain: Schema
+    status: active
+    schema_url: https://gingin77.github.io/aopwiki_emod_web_app/
+    contacts: gingin77
+    github_stars: 1
+  cmungall/basin3d_schema:
+    title: basin3d_schema
+    description: EXPERIMENTAL
+    github_repo: https://github.com/cmungall/basin3d_schema
+    license: BSD-3-Clause
+    domain: Computer Science
+    status: active
+    topics:
+    - environmental-data
+    - exemplar
+    - linkml
+    schema_url: https://cmungall.github.io/basin3d_schema
+    contacts: cmungall
+    github_stars: 1
+  ARPA-H-BDF/bdfkb-schema:
+    title: bdfkb-schema
+    github_repo: https://github.com/ARPA-H-BDF/bdfkb-schema
+    license: Apache-2.0
+    domain: Schema
+    status: maintenance
+    schema_url: https://arpa-h-bdf.github.io/bdfkb-schema/
+    contacts: ARPA-H-BDF
+    github_stars: 1
+  cmungall/bridge-schemas:
+    title: bridge-schemas
+    github_repo: https://github.com/cmungall/bridge-schemas
+    domain: Schema
+    status: active
+    schema_url: https://cmungall.github.io/bridge-schemas
+    contacts: cmungall
+    github_stars: 1
+  cellannotation/cas-tools:
+    title: cas-tools
+    description: Cell Annotation Schema Tools
+    github_repo: https://github.com/cellannotation/cas-tools
+    domain: Schema
+    status: maintenance
+    schema_url: https://cellannotation.github.io/cas-tools/
+    contacts: cellannotation
+    github_stars: 1
+  cmungall/comet:
+    title: comet
+    github_repo: https://github.com/cmungall/comet
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://cmungall.github.io/comet/
+    contacts: cmungall
+    github_stars: 1
+  sierra-moxon/ctd_ingest:
+    title: ctd_ingest
+    github_repo: https://github.com/sierra-moxon/ctd_ingest
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/ctd_ingest/
+    contacts: sierra-moxon
+    github_stars: 1
+  sujaypatil96/ga4gh-va-schema:
+    title: ga4gh-va-schema
+    description: Data model for variant annotation in the GA4GH consortium.
+    github_repo: https://github.com/sujaypatil96/ga4gh-va-schema
+    license: MIT
+    domain: Computer Science
+    status: active
+    topics:
+    - ga4gh
+    - linkml
+    - schema
+    schema_url: https://sujaypatil96.github.io/ga4gh-va-schema/
+    contacts: sujaypatil96
+    github_stars: 1
+  Knowledge-Graph-Hub/kg-envpolyreg:
+    title: kg-envpolyreg
+    github_repo: https://github.com/Knowledge-Graph-Hub/kg-envpolyreg
+    license: BSD-3-Clause
+    domain: Schema
+    status: maintenance
+    schema_url: https://knowledge-graph-hub.github.io/kg-envpolyreg/
+    contacts: Knowledge-Graph-Hub
+    github_stars: 1
+  genophenoenvo/knowledge-graph:
+    title: knowledge-graph
+    github_repo: https://github.com/genophenoenvo/knowledge-graph
+    license: BSD-3-Clause
+    domain: Schema
+    status: inactive
+    schema_url: https://genophenoenvo.github.io/knowledge-graph/
+    contacts: genophenoenvo
+    github_stars: 1
+  chicagopcdc/linkml-data-dictionary:
+    title: linkml-data-dictionary
+    description: Define the data dictionary using LinkML for data validation and reusable artifacts. (Proof of concept)
+    github_repo: https://github.com/chicagopcdc/linkml-data-dictionary
+    domain: Computer Science
+    status: inactive
+    schema_url: https://chicagopcdc.github.io/linkml-data-dictionary/
+    contacts: chicagopcdc
+    github_stars: 1
+  brreg/linkml-datamodellering-no:
+    title: linkml-datamodellering-no
+    description: "LinkML-modeller for norske W3C-applikasjonsprofiler og domenemodeller, med MCP-verkt\xF8y for KI-st\xF8\
+      tta generering og validering, og dokumentasjonsportal."
+    github_repo: https://github.com/brreg/linkml-datamodellering-no
+    license: MIT
+    domain: Computer Science
+    status: active
+    schema_url: https://brreg.github.io/linkml-datamodellering-no/
+    contacts: brreg
+    github_stars: 1
+  microbiomedata/metadata_converter:
+    title: metadata_converter
+    description: Conversion of schemas/templates/metadata to biolinkml
+    github_repo: https://github.com/microbiomedata/metadata_converter
+    domain: Biology
+    status: inactive
+    schema_url: https://microbiomedata.github.io/metadata_converter/
+    contacts: microbiomedata
+    github_stars: 1
+  sdsc-ordes/modos-schema:
+    title: modos-schema
+    description: Metadata schema for the Multi-Omics Digital-Object
+    github_repo: https://github.com/sdsc-ordes/modos-schema
+    license: Apache-2.0
+    domain: Biology
+    status: maintenance
+    topics:
+    - omics
+    - ontology
+    schema_url: https://sdsc-ordes.github.io/modos-schema
+    contacts: sdsc-ordes
+    github_stars: 1
+  kjappelbaum/mofdscribe-schema:
+    title: mofdscribe-schema
+    github_repo: https://github.com/kjappelbaum/mofdscribe-schema
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://kjappelbaum.github.io/mofdscribe-schema/
+    contacts: kjappelbaum
+    github_stars: 1
+  jeffbaumes/nmdc-client:
+    title: nmdc-client
+    description: A Python client for the National Microbiome Data Collaborative
+    github_repo: https://github.com/jeffbaumes/nmdc-client
+    domain: Biology
+    status: inactive
+    schema_url: https://jeffbaumes.github.io/nmdc-client/
+    contacts: jeffbaumes
+    github_stars: 1
+  PlasmoGenEpi/portable-microhaplotype-object:
+    title: portable-microhaplotype-object
+    description: A schema to define the minimum amount of data needed to export a microhaplotype calling pipeline analysis
+      with associated metadata
+    github_repo: https://github.com/PlasmoGenEpi/portable-microhaplotype-object
+    license: GPL-3.0
+    domain: Schema
+    status: active
+    schema_url: https://plasmogenepi.github.io/portable-microhaplotype-object/
+    contacts: PlasmoGenEpi
+    github_stars: 1
+  Open-Ecological-Technology/resume-model:
+    title: resume-model
+    description: m30ml example project for rendering a resume
+    github_repo: https://github.com/Open-Ecological-Technology/resume-model
+    domain: Computer Science
+    status: active
+    schema_url: https://open-ecological-technology.github.io/resume-model/
+    contacts: Open-Ecological-Technology
+    github_stars: 1
+  monarch-initiative/rppr_stats:
+    title: rppr_stats
+    github_repo: https://github.com/monarch-initiative/rppr_stats
+    domain: Schema
+    status: inactive
+    schema_url: https://monarch-initiative.github.io/rppr_stats/
+    contacts: monarch-initiative
+    github_stars: 1
+  axenov/SketchML:
+    title: SketchML
+    description: ':whale: SketchML - distributed Machine Leaning framework for Apache Flink :star:'
+    github_repo: https://github.com/axenov/SketchML
+    domain: Computer Science
+    status: inactive
+    schema_url: https://axenov.github.io/SketchML/
+    contacts: axenov
+    github_stars: 1
+  NCATS-Tangerine/smpdb-beacon:
+    title: smpdb-beacon
+    github_repo: https://github.com/NCATS-Tangerine/smpdb-beacon
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://ncats-tangerine.github.io/smpdb-beacon/
+    contacts: NCATS-Tangerine
+    github_stars: 1
+  microbiomedata/submission-schema:
+    title: submission-schema
+    description: The NMDC submission schema
+    github_repo: https://github.com/microbiomedata/submission-schema
+    license: MIT
+    domain: Schema
+    status: active
+    schema_url: https://microbiomedata.github.io/submission-schema/
+    contacts: microbiomedata
+    github_stars: 1
+  timsbiomed/tccm-model-lite:
+    title: tccm-model-lite
+    github_repo: https://github.com/timsbiomed/tccm-model-lite
+    domain: Schema
+    status: inactive
+    schema_url: https://timsbiomed.github.io/tccm-model-lite/
+    contacts: timsbiomed
+    github_stars: 1
+  monarch-initiative/alliance-phenotype-association-ingest:
+    title: alliance-phenotype-association-ingest
+    github_repo: https://github.com/monarch-initiative/alliance-phenotype-association-ingest
+    license: BSD-3-Clause
+    domain: Schema
+    status: inactive
+    schema_url: https://monarch-initiative.github.io/alliance-phenotype-association-ingest/
+    contacts: monarch-initiative
+  alspac/alspac-data-catalogue-schema:
+    title: alspac-data-catalogue-schema
+    description: This repo is for the schema of alspac data catalogues and meta data for alspac data sets
+    github_repo: https://github.com/alspac/alspac-data-catalogue-schema
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://alspac.github.io/alspac-data-catalogue-schema/
+    contacts: alspac
+  Sveino/arcZcode:
+    title: arcZcode
+    description: Architecture as Code
+    github_repo: https://github.com/Sveino/arcZcode
+    license: Apache-2.0
+    domain: Schema
+    status: inactive
+    schema_url: https://sveino.github.io/arcZcode/
+    contacts: Sveino
+  sierra-moxon/automate_mappings:
+    title: automate_mappings
+    github_repo: https://github.com/sierra-moxon/automate_mappings
+    domain: Schema
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/automate_mappings/
+    contacts: sierra-moxon
+  groenewt/bashtown:
+    title: bashtown
+    description: bash town
+    github_repo: https://github.com/groenewt/bashtown
+    domain: Schema
+    status: active
+    schema_url: https://groenewt.github.io/bashtown/
+    contacts: groenewt
+  diatomsRcool/biotic-interactions:
+    title: biotic-interactions
+    description: LinkML model for biotic interactions - designed for use with OntoGPT
+    github_repo: https://github.com/diatomsRcool/biotic-interactions
+    domain: Biology
+    status: inactive
+    schema_url: https://diatomsrcool.github.io/biotic-interactions/
+    contacts: diatomsRcool
+  Cellular-Semantics/cell-annotation-schema:
+    title: cell-annotation-schema
+    description: A general, open-standard schema for cell annotations and related metadata.
+    github_repo: https://github.com/Cellular-Semantics/cell-annotation-schema
+    license: GPL-3.0
+    domain: Schema
+    status: maintenance
+    schema_url: https://cellular-semantics.github.io/cell-annotation-schema/
+    contacts: Cellular-Semantics
+  sierra-moxon/clinical-studies-schema:
+    title: clinical-studies-schema
+    github_repo: https://github.com/sierra-moxon/clinical-studies-schema
+    license: MIT
+    domain: Clinical
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/clinical-studies-schema/
+    contacts: sierra-moxon
+  NCATS-Tangerine/CPKG:
+    title: CPKG
+    description: Translation tools for ClinicalProfile to Knowledge Graphs
+    github_repo: https://github.com/NCATS-Tangerine/CPKG
+    domain: Clinical
+    status: inactive
+    schema_url: https://ncats-tangerine.github.io/CPKG/
+    contacts: NCATS-Tangerine
+  ml-evs/datalab-schemas:
+    title: datalab-schemas
+    description: Core schemas for datalab.
+    github_repo: https://github.com/ml-evs/datalab-schemas
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://ml-evs.github.io/datalab-schemas/
+    contacts: ml-evs
+  In2PrimateBrains/DataMetadataWorkflowDocs:
+    title: DataMetadataWorkflowDocs
+    description: Documentation for In2PrimateBrains Data and Metadata Workflows
+    github_repo: https://github.com/In2PrimateBrains/DataMetadataWorkflowDocs
+    domain: Neuroscience
+    status: inactive
+    schema_url: https://in2primatebrains.github.io/DataMetadataWorkflowDocs/
+    contacts: In2PrimateBrains
+  OP-TED/entity-resolution-spec:
+    title: entity-resolution-spec
+    description: Formal software contract, shared data models, sample messages, and compliance tests required for integrating
+      new Entity Resolution Engines (EREs) into the system.
+    github_repo: https://github.com/OP-TED/entity-resolution-spec
+    domain: Computer Science
+    status: active
+    schema_url: https://op-ted.github.io/entity-resolution-spec/
+    contacts: OP-TED
+  heycatwonton/EssDiveSampleRFOld:
+    title: EssDiveSampleRFOld
+    github_repo: https://github.com/heycatwonton/EssDiveSampleRFOld
+    license: CC0-1.0
+    domain: Schema
+    status: inactive
+    schema_url: https://heycatwonton.github.io/EssDiveSampleRFOld/
+    contacts: heycatwonton
+  hsolbrig/foo-model:
+    title: foo-model
+    github_repo: https://github.com/hsolbrig/foo-model
+    domain: Schema
+    status: inactive
+    schema_url: https://hsolbrig.github.io/foo-model/
+    contacts: hsolbrig
+  jundahuang9123/General-Ontology-Editor:
+    title: General-Ontology-Editor
+    github_repo: https://github.com/jundahuang9123/General-Ontology-Editor
+    domain: Schema
+    status: active
+    schema_url: https://jundahuang9123.github.io/General-Ontology-Editor/
+    contacts: jundahuang9123
+  mukundanps/ghp-vocab:
+    title: ghp-vocab
+    description: Vocabulary for Good Health Pass
+    github_repo: https://github.com/mukundanps/ghp-vocab
+    domain: Clinical
+    status: inactive
+    schema_url: https://mukundanps.github.io/ghp-vocab/
+    contacts: mukundanps
+  rly/hdmf-term-lists:
+    title: hdmf-term-lists
+    github_repo: https://github.com/rly/hdmf-term-lists
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://rly.github.io/hdmf-term-lists/
+    contacts: rly
+  cmungall/hoopla:
+    title: hoopla
+    github_repo: https://github.com/cmungall/hoopla
+    license: BSD-3-Clause
+    domain: Schema
+    status: inactive
+    schema_url: https://cmungall.github.io/hoopla/
+    contacts: cmungall
+  ritger-alliander/im-measurement:
+    title: im-measurement
+    description: Measurement Profile
+    github_repo: https://github.com/ritger-alliander/im-measurement
+    license: Apache-2.0
+    domain: Schema
+    status: inactive
+    schema_url: https://ritger-alliander.github.io/im-measurement/
+    contacts: ritger-alliander
+  ree-gupta/in2pb-linkml-test:
+    title: in2pb-linkml-test
+    github_repo: https://github.com/ree-gupta/in2pb-linkml-test
+    domain: Computer Science
+    status: inactive
+    schema_url: https://ree-gupta.github.io/in2pb-linkml-test/
+    contacts: ree-gupta
+  hsolbrig/jsonasobj:
+    title: jsonasobj
+    description: Extension to the python json library that represents JSON as first class python objects.
+    github_repo: https://github.com/hsolbrig/jsonasobj
+    license: CC0-1.0
+    domain: Schema
+    status: inactive
+    schema_url: https://hsolbrig.github.io/jsonasobj/
+    contacts: hsolbrig
+  cmungall/linkml-cfde:
+    title: linkml-cfde
+    description: EXPERIMENTAL rendering of Common Fund Data Ecocystem as LinkML
+    github_repo: https://github.com/cmungall/linkml-cfde
+    license: MIT
+    domain: Computer Science
+    status: inactive
+    schema_url: https://cmungall.github.io/linkml-cfde/
+    contacts: cmungall
+  hsolbrig/linkml-enhanced-template:
+    title: linkml-enhanced-template
+    description: Linkml template playground
+    github_repo: https://github.com/hsolbrig/linkml-enhanced-template
+    domain: Computer Science
+    status: inactive
+    schema_url: https://hsolbrig.github.io/linkml-enhanced-template/
+    contacts: hsolbrig
+  manulera/linkml-playground:
+    title: linkml-playground
+    description: linkml-playground
+    github_repo: https://github.com/manulera/linkml-playground
+    domain: Computer Science
+    status: inactive
+    schema_url: https://manulera.github.io/linkml-playground/
+    contacts: manulera
   lmnb2055/LinkML-Project-Cookiecutter:
     title: LinkML-Project-Cookiecutter
     description: This project is from the LinkML tutorial at ISMB 2024
@@ -628,3 +2061,202 @@ entries:
     status: active
     schema_url: https://lmnb2055.github.io/LinkML-Project-Cookiecutter/
     contacts: lmnb2055
+  sumirp/linkml-tutorial-2024:
+    title: linkml-tutorial-2024
+    github_repo: https://github.com/sumirp/linkml-tutorial-2024
+    license: MIT
+    domain: Computer Science
+    status: inactive
+    schema_url: https://sumirp.github.io/linkml-tutorial-2024/
+    contacts: sumirp
+  dbujold/linkml-tutorial-2024:
+    title: linkml-tutorial-2024
+    github_repo: https://github.com/dbujold/linkml-tutorial-2024
+    license: Apache-2.0
+    domain: Computer Science
+    status: inactive
+    schema_url: https://dbujold.github.io/linkml-tutorial-2024/
+    contacts: dbujold
+  MontpellierRessourcesImagerie/microscopemetrics-schema:
+    title: microscopemetrics-schema
+    github_repo: https://github.com/MontpellierRessourcesImagerie/microscopemetrics-schema
+    license: GPL-3.0
+    domain: Schema
+    status: active
+    schema_url: https://montpellierressourcesimagerie.github.io/microscopemetrics-schema/
+    contacts: MontpellierRessourcesImagerie
+  sierra-moxon/nmdc-patterns:
+    title: nmdc-patterns
+    github_repo: https://github.com/sierra-moxon/nmdc-patterns
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/nmdc-patterns/
+    contacts: sierra-moxon
+  liuji1031/ontology_to_schema:
+    title: ontology_to_schema
+    github_repo: https://github.com/liuji1031/ontology_to_schema
+    domain: Schema
+    status: inactive
+    schema_url: https://liuji1031.github.io/ontology_to_schema/
+    contacts: liuji1031
+  multimeric/PCDMLinkML:
+    title: PCDMLinkML
+    description: Portland Common Data Model, in LinkML
+    github_repo: https://github.com/multimeric/PCDMLinkML
+    domain: Computer Science
+    status: inactive
+    schema_url: https://multimeric.github.io/PCDMLinkML/
+    contacts: multimeric
+  wd15/pfhub-cli-old:
+    title: pfhub-cli-old
+    github_repo: https://github.com/wd15/pfhub-cli-old
+    license: NOASSERTION
+    domain: Schema
+    status: inactive
+    schema_url: https://wd15.github.io/pfhub-cli-old/
+    contacts: wd15
+  usnistgov/pfhub-schema:
+    title: pfhub-schema
+    description: Phase-field simulation and benchmark schema in LinkML
+    github_repo: https://github.com/usnistgov/pfhub-schema
+    license: NOASSERTION
+    domain: Computer Science
+    status: inactive
+    schema_url: https://usnistgov.github.io/pfhub-schema/
+    contacts: usnistgov
+  yaseminbridges/pheval.amelie:
+    title: pheval.amelie
+    github_repo: https://github.com/yaseminbridges/pheval.amelie
+    license: Apache-2.0
+    domain: Schema
+    status: inactive
+    schema_url: https://yaseminbridges.github.io/pheval.amelie/
+    contacts: yaseminbridges
+  NCATS-Tangerine/rhea-beacon:
+    title: rhea-beacon
+    description: Knowledge Beacon wrapper for the Rhea Annotated Reactions database (https://www.rhea-db.org)
+    github_repo: https://github.com/NCATS-Tangerine/rhea-beacon
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://ncats-tangerine.github.io/rhea-beacon/
+    contacts: NCATS-Tangerine
+  sierra-moxon/schema-automator-monarch:
+    title: schema-automator-monarch
+    github_repo: https://github.com/sierra-moxon/schema-automator-monarch
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/schema-automator-monarch/
+    contacts: sierra-moxon
+  vemonet/semanticscience-model:
+    title: semanticscience-model
+    description: LinkML model for the SemanticScience Integrated Ontology
+    github_repo: https://github.com/vemonet/semanticscience-model
+    domain: Computer Science
+    status: inactive
+    topics:
+    - knowledge-graph
+    - ontology
+    - owl-ontology
+    - semanticscience
+    - shacl
+    schema_url: https://vemonet.github.io/semanticscience-model
+    contacts: vemonet
+  clingen-data-model/sepio-models:
+    title: sepio-models
+    description: Shared SEPIO models based on the bioLinkML modeling language supporting the metakb and clingen sepio statements.
+    github_repo: https://github.com/clingen-data-model/sepio-models
+    license: CC0-1.0
+    domain: Biology
+    status: inactive
+    schema_url: https://clingen-data-model.github.io/sepio-models/
+    contacts: clingen-data-model
+  sneakers-the-rat/slides:
+    title: slides
+    description: collectin my slides instead of having them be all over everywhere
+    github_repo: https://github.com/sneakers-the-rat/slides
+    license: AGPL-3.0
+    domain: Schema
+    status: inactive
+    schema_url: https://sneakers-the-rat.github.io/slides/
+    contacts: sneakers-the-rat
+  iarpa-felix/synbio-schema:
+    title: synbio-schema
+    description: A schema for synthetic biology, inspired by IARPA FELIX
+    github_repo: https://github.com/iarpa-felix/synbio-schema
+    license: MIT
+    domain: Biology
+    status: inactive
+    schema_url: https://semantic-synbio.github.io/synbio-schema/
+    contacts: iarpa-felix
+  turbomam/tank-schema:
+    title: tank-schema
+    github_repo: https://github.com/turbomam/tank-schema
+    license: MIT
+    domain: Schema
+    status: inactive
+    schema_url: https://turbomam.github.io/tank-schema/
+    contacts: turbomam
+  timsbiomed/tccm-api:
+    title: tccm-api
+    github_repo: https://github.com/timsbiomed/tccm-api
+    license: CC0-1.0
+    domain: Schema
+    status: inactive
+    schema_url: https://timsbiomed.github.io/tccm-api/
+    contacts: timsbiomed
+  hsolbrig/template-fun-model:
+    title: template-fun-model
+    description: Demo
+    github_repo: https://github.com/hsolbrig/template-fun-model
+    domain: Schema
+    status: inactive
+    schema_url: https://hsolbrig.github.io/template-fun-model/
+    contacts: hsolbrig
+  dalito/test-linkml-project-copier:
+    title: test-linkml-project-copier
+    description: Test project created from copier template
+    github_repo: https://github.com/dalito/test-linkml-project-copier
+    license: MIT
+    domain: Computer Science
+    status: maintenance
+    schema_url: https://dalito.github.io/test-linkml-project-copier/
+    contacts: dalito
+  NCATS-Tangerine/tkg-beacon:
+    title: tkg-beacon
+    description: Knowledge Beacon wrapper of a Translator Knowledge Graph data model compliant Neo4j Database
+    github_repo: https://github.com/NCATS-Tangerine/tkg-beacon
+    license: NOASSERTION
+    domain: Schema
+    status: inactive
+    schema_url: https://ncats-tangerine.github.io/tkg-beacon/
+    contacts: NCATS-Tangerine
+  melonora/vega-scverse:
+    title: vega-scverse
+    description: Vega specifications used for visualization in the scverse ecosystem.
+    github_repo: https://github.com/melonora/vega-scverse
+    license: BSD-3-Clause
+    domain: Infrastructure
+    status: maintenance
+    schema_url: https://melonora.github.io/vega-scverse/
+    contacts: melonora
+  sierra-moxon/vrs_linkml:
+    title: vrs_linkml
+    description: LinkML Version of the GA4GH Variation Representation Specification
+    github_repo: https://github.com/sierra-moxon/vrs_linkml
+    license: MIT
+    domain: Computer Science
+    status: inactive
+    schema_url: https://sierra-moxon.github.io/vrs_linkml/
+    contacts: sierra-moxon
+  biodatamodels/vrsatile:
+    title: vrsatile
+    description: Experimental LinkML repository for vrsatile (a GAG4H standard).
+    github_repo: https://github.com/biodatamodels/vrsatile
+    license: MIT
+    domain: Computer Science
+    status: inactive
+    schema_url: https://biodatamodels.github.io/vrsatile/
+    contacts: biodatamodels

--- a/src/scripts/discover_linkml_repos.py
+++ b/src/scripts/discover_linkml_repos.py
@@ -9,6 +9,7 @@ in pyproject.toml and requirements.txt files.
 import os
 import sys
 import json
+import random
 import yaml
 import requests
 from pathlib import Path
@@ -17,6 +18,10 @@ import click
 from datetime import datetime
 import time
 from enum import Enum
+
+
+class RateLimitExhaustedError(RuntimeError):
+    """Raised when GitHub rate-limit retries are exhausted for a single request."""
 
 
 class ExcludeList(Enum):
@@ -83,6 +88,11 @@ def is_excluded_repository(repo: Dict[str, Any]) -> bool:
 class GitHubSearchDiscovery:
     """Discover LinkML projects using GitHub Search REST API."""
     
+    # Retry/backoff configuration for GitHub rate limits.
+    MAX_RETRIES = 5
+    BACKOFF_SCHEDULE = [30, 60, 120, 300, 600]  # seconds, per retry attempt
+    MAX_RESET_WAIT = 15 * 60  # cap on waiting for X-RateLimit-Reset, seconds
+
     def __init__(self, token: Optional[str] = None):
         """Initialize with GitHub token."""
         self.token = token or os.getenv('GITHUB_TOKEN') or os.getenv('GH_TOKEN')
@@ -94,8 +104,168 @@ class GitHubSearchDiscovery:
                 'Authorization': f'token {self.token}',
                 'Accept': 'application/vnd.github.v3+json'
             }
-        
+
         self.base_url = 'https://api.github.com'
+        # Queries that exhausted retries and were skipped. Inspected by the caller
+        # to decide whether to fail the run.
+        self.failed_queries: List[str] = []
+        # Cache of /repos/{full_name} lookups. Value is None when the lookup
+        # failed (and was recorded in failed_queries). Used both to avoid
+        # duplicate API calls and to enrich the minimal repository objects that
+        # GitHub returns for code-search / README-search results.
+        self._repo_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+
+    def _compute_sleep_seconds(self, response: requests.Response, attempt: int) -> float:
+        """Pick a sleep duration after a 403/429 based on response headers.
+
+        Priority:
+          1. Retry-After header (secondary rate limit / abuse detection).
+          2. X-RateLimit-Reset when X-RateLimit-Remaining == 0 (primary limit).
+          3. Exponential backoff schedule.
+        Jitter is added to avoid synchronized retries.
+        """
+        retry_after = response.headers.get('Retry-After')
+        if retry_after:
+            try:
+                return float(retry_after) + random.uniform(0, 2)
+            except ValueError:
+                pass
+
+        remaining = response.headers.get('X-RateLimit-Remaining')
+        reset = response.headers.get('X-RateLimit-Reset')
+        if remaining is not None and reset is not None:
+            try:
+                if int(remaining) == 0:
+                    wait = int(reset) - int(time.time())
+                    if wait > 0:
+                        return min(wait, self.MAX_RESET_WAIT) + random.uniform(0, 2)
+            except ValueError:
+                pass
+
+        idx = min(attempt, len(self.BACKOFF_SCHEDULE) - 1)
+        return self.BACKOFF_SCHEDULE[idx] + random.uniform(0, 5)
+
+    def _proactive_throttle(self, response: requests.Response) -> None:
+        """If we are about to exhaust the rate limit, sleep until reset."""
+        remaining = response.headers.get('X-RateLimit-Remaining')
+        reset = response.headers.get('X-RateLimit-Reset')
+        if remaining is None or reset is None:
+            return
+        try:
+            remaining_int = int(remaining)
+            reset_int = int(reset)
+        except ValueError:
+            return
+        if remaining_int < 3:
+            wait = reset_int - int(time.time())
+            if wait > 0:
+                wait = min(wait, self.MAX_RESET_WAIT)
+                print(f"  Rate limit nearly exhausted ({remaining_int} remaining); sleeping {wait}s until reset")
+                time.sleep(wait + random.uniform(0, 2))
+
+    def _request_with_retry(self, url: str, params: Optional[Dict[str, Any]] = None,
+                            description: str = '') -> requests.Response:
+        """GET ``url`` with retries that honor GitHub's rate-limit headers.
+
+        Raises RateLimitExhaustedError after MAX_RETRIES rate-limited attempts.
+        Raises requests.RequestException for non-rate-limit network errors after
+        MAX_RETRIES.
+        """
+        last_response: Optional[requests.Response] = None
+        last_exc: Optional[Exception] = None
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                response = requests.get(url, headers=self.headers, params=params, timeout=30)
+            except requests.RequestException as exc:
+                last_exc = exc
+                sleep_s = self.BACKOFF_SCHEDULE[min(attempt, len(self.BACKOFF_SCHEDULE) - 1)]
+                print(f"  Network error on {description or url}: {exc}; retrying in {sleep_s}s "
+                      f"(attempt {attempt + 1}/{self.MAX_RETRIES})")
+                time.sleep(sleep_s + random.uniform(0, 5))
+                continue
+
+            last_response = response
+
+            if response.status_code in (403, 429):
+                # Distinguish rate limit from a real 403 (e.g. permission denied).
+                body_msg = ''
+                try:
+                    body_msg = (response.json().get('message') or '').lower()
+                except (ValueError, AttributeError):
+                    body_msg = ''
+                is_rate_limit = (
+                    response.status_code == 429
+                    or 'rate limit' in body_msg
+                    or 'abuse detection' in body_msg
+                    or response.headers.get('X-RateLimit-Remaining') == '0'
+                    or response.headers.get('Retry-After') is not None
+                )
+                if not is_rate_limit:
+                    # A real 403 (e.g. forbidden); do not retry.
+                    return response
+
+                sleep_s = self._compute_sleep_seconds(response, attempt)
+                kind = 'secondary' if 'abuse' in body_msg or 'secondary' in body_msg else 'primary'
+                print(f"  Hit GitHub {kind} rate limit on {description or url} "
+                      f"(status {response.status_code}); sleeping {sleep_s:.1f}s "
+                      f"(attempt {attempt + 1}/{self.MAX_RETRIES})")
+                time.sleep(sleep_s)
+                continue
+
+            # Success or non-rate-limit error: let caller decide.
+            self._proactive_throttle(response)
+            return response
+
+        if last_response is not None:
+            raise RateLimitExhaustedError(
+                f"Rate limit retries exhausted for {description or url}: "
+                f"last status {last_response.status_code}"
+            )
+        raise RateLimitExhaustedError(
+            f"Network retries exhausted for {description or url}: {last_exc}"
+        )
+
+    def _fetch_full_repo(self, full_name: str) -> Optional[Dict[str, Any]]:
+        """Fetch canonical repo metadata via /repos/{full_name}.
+
+        Results are cached so the same repo is not refetched across the many
+        code-search queries that may surface it. Returns None on failure (rate
+        limit exhausted, 404, network error). The minimal repository object
+        embedded in code-search results lacks stargazers_count, license,
+        archived, and topics, so we need this to get accurate metadata.
+        """
+        if full_name in self._repo_cache:
+            return self._repo_cache[full_name]
+
+        url = f"{self.base_url}/repos/{full_name}"
+        try:
+            response = self._request_with_retry(
+                url, description=f"repo metadata {full_name}"
+            )
+        except RateLimitExhaustedError as exc:
+            print(f"  Rate limit hit fetching {full_name}: {exc}")
+            self.failed_queries.append(f"repo-meta:{full_name}")
+            self._repo_cache[full_name] = None
+            return None
+        except requests.RequestException as exc:
+            print(f"  Network error fetching {full_name}: {exc}")
+            self._repo_cache[full_name] = None
+            return None
+
+        if response.status_code != 200:
+            print(f"  Failed to fetch {full_name}: HTTP {response.status_code}")
+            self._repo_cache[full_name] = None
+            return None
+
+        try:
+            data = response.json()
+        except ValueError:
+            self._repo_cache[full_name] = None
+            return None
+
+        self._repo_cache[full_name] = data
+        return data
 
     def search_linkml_repositories(self) -> List[Dict[str, Any]]:
         """Search for repositories that have LinkML dependencies."""
@@ -131,7 +301,7 @@ class GitHubSearchDiscovery:
                     print(f"  Skipped fork: {full_name}")
             
             # Conservative rate limiting for REST API
-            time.sleep(2)
+            time.sleep(5)
         
         # Search README files for LinkML content using code search
         if self.token:
@@ -144,32 +314,37 @@ class GitHubSearchDiscovery:
             for query in readme_search_queries:
                 print(f"README search: {query}")
                 code_results = self._search_readme_content(query)
-                
+
                 for result in code_results:
-                    repo = result.get('repository', {})
-                    full_name = repo.get('full_name', '')
-                    
+                    minimal_repo = result.get('repository', {})
+                    full_name = minimal_repo.get('full_name', '')
+
                     if not full_name:
                         continue
-                        
+
                     # Skip repos from the linkml organization itself
                     if full_name.startswith('linkml/'):
                         print(f"  Skipped linkml org repo: {full_name}")
                         continue
+
+                    # The README/code-search "repository" object lacks stars,
+                    # license, archived, and topics; enrich via /repos/{name}.
+                    repo = self._fetch_full_repo(full_name) or minimal_repo
+
                     # Skip excluded repositories
                     if is_excluded_repository(repo):
                         continue
-                        
+
                     if full_name not in all_repos and not repo.get('fork', False):
                         all_repos[full_name] = repo
-                        stars = repo.get('stargazers_count', 0)
+                        stars = repo.get('stargazers_count', 0) or 0
                         print(f"  Found in README: {full_name} ({stars} stars)")
                     elif repo.get('fork', False):
                         print(f"  Skipped fork: {full_name}")
-                
+
                 # Conservative rate limiting for code search
-                time.sleep(6)
-        
+                time.sleep(10)
+
         # Then, search for linkml in specific files using REST code search
         if self.token:
             file_search_queries = [
@@ -222,16 +397,20 @@ class GitHubSearchDiscovery:
                         print(f"  Skipped fork: {full_name}")
                 
                 # Conservative rate limiting for code search (stricter limits than repo search)
-                time.sleep(6)
+                time.sleep(10)
         else:
             print("Skipping file searches - requires GitHub token for code search API")
         
         print(f"\nTotal unique repositories found: {len(all_repos)}")
+        if self.failed_queries:
+            print(f"\nWARNING: {len(self.failed_queries)} search queries were dropped after exhausting retries:")
+            for q in self.failed_queries:
+                print(f"  - {q}")
         return list(all_repos.values())
     
     def _search_repositories(self, query: str, per_page: int = 50) -> List[Dict[str, Any]]:
         """Execute repository search using GitHub Search API."""
-        
+
         url = f"{self.base_url}/search/repositories"
         params = {
             'q': query,
@@ -239,30 +418,36 @@ class GitHubSearchDiscovery:
             'order': 'desc',
             'per_page': per_page
         }
-        
+
         try:
-            response = requests.get(url, headers=self.headers, params=params)
-            
-            if response.status_code == 403:
-                print(f"  Rate limit exceeded for query: {query}")
-                return []
-            elif response.status_code != 200:
-                print(f"  Search failed for query '{query}': {response.status_code}")
-                return []
-            
-            data = response.json()
-            return data.get('items', [])
-            
-        except Exception as e:
-            print(f"  Error searching for '{query}': {e}")
+            response = self._request_with_retry(url, params=params,
+                                                description=f"repo search '{query}'")
+        except RateLimitExhaustedError as exc:
+            print(f"  {exc}")
+            self.failed_queries.append(f"repo:{query}")
             return []
+        except requests.RequestException as exc:
+            print(f"  Error searching for '{query}': {exc}")
+            self.failed_queries.append(f"repo:{query}")
+            return []
+
+        if response.status_code != 200:
+            print(f"  Search failed for query '{query}': {response.status_code}")
+            return []
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            print(f"  Invalid JSON for query '{query}': {exc}")
+            return []
+        return data.get('items', [])
     
     def _search_readme_content(self, search_string: str, per_page: int = 30) -> List[Dict[str, Any]]:
         """Search for a string in README.md files using GitHub's code search API."""
-        
+
         if not self.token:
             return []
-            
+
         url = f"{self.base_url}/search/code"
         query = f"{search_string} in:file filename:README.md"
         params = {
@@ -271,28 +456,37 @@ class GitHubSearchDiscovery:
         }
 
         try:
-            response = requests.get(url, headers=self.headers, params=params)
-            
-            if response.status_code == 403:
-                print(f"  Rate limit exceeded for query: {query}")
-                return []
-            elif response.status_code != 200:
-                print(f"  Search failed for query '{query}': {response.status_code}")
-                return []
-            
-            data = response.json()
-            return data.get('items', [])
-            
-        except Exception as e:
-            print(f"  Error searching for '{query}': {e}")
+            response = self._request_with_retry(url, params=params,
+                                                description=f"readme search '{query}'")
+        except RateLimitExhaustedError as exc:
+            print(f"  {exc}")
+            self.failed_queries.append(f"readme:{query}")
             return []
+        except requests.RequestException as exc:
+            print(f"  Error searching for '{query}': {exc}")
+            self.failed_queries.append(f"readme:{query}")
+            return []
+
+        if response.status_code == 422:
+            print(f"  README search query invalid: {query}")
+            return []
+        if response.status_code != 200:
+            print(f"  Search failed for query '{query}': {response.status_code}")
+            return []
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            print(f"  Invalid JSON for query '{query}': {exc}")
+            return []
+        return data.get('items', [])
     
     def _search_code_rest(self, query: str, per_page: int = 20) -> List[Dict[str, Any]]:
         """Search for code using GitHub REST API code search."""
-        
+
         if not self.token:
             return []
-        
+
         url = f"{self.base_url}/search/code"
         params = {
             'q': query,
@@ -300,68 +494,75 @@ class GitHubSearchDiscovery:
             'order': 'desc',
             'per_page': per_page
         }
-        
+
         try:
-            response = requests.get(url, headers=self.headers, params=params)
-            
-            if response.status_code == 403:
-                print(f"  Rate limit exceeded for code search: {query}")
-                print("Waiting 60 seconds before continuing...")
-                time.sleep(60)
-                return []
-            elif response.status_code == 422:
-                print(f"  Code search query invalid: {query}")
-                return []
-            elif response.status_code != 200:
-                print(f"  Code search failed for query '{query}': {response.status_code}")
-                return []
-            
+            response = self._request_with_retry(url, params=params,
+                                                description=f"code search '{query}'")
+        except RateLimitExhaustedError as exc:
+            print(f"  {exc}")
+            self.failed_queries.append(f"code:{query}")
+            return []
+        except requests.RequestException as exc:
+            print(f"  Error in code search for '{query}': {exc}")
+            self.failed_queries.append(f"code:{query}")
+            return []
+
+        if response.status_code == 422:
+            print(f"  Code search query invalid: {query}")
+            return []
+        if response.status_code != 200:
+            print(f"  Code search failed for query '{query}': {response.status_code}")
+            return []
+
+        try:
             data = response.json()
-            
-            # Check rate limit headers
-            rate_limit_remaining = response.headers.get('X-RateLimit-Remaining')
-            if rate_limit_remaining and int(rate_limit_remaining) < 5:
-                print(f"  Code search rate limit low ({rate_limit_remaining} remaining), slowing down...")
-                time.sleep(10)
-            
-            # Extract unique repositories from code search results
-            repos = []
-            repo_names_seen = set()
-            
-            for item in data.get('items', []):
-                repo_data = item['repository']
-                repo_name = repo_data['full_name']
-                
-                # Skip if we've already processed this repository
-                if repo_name in repo_names_seen:
-                    continue
-                repo_names_seen.add(repo_name)
-                
-                # Convert to standard format
-                repo = {
+        except ValueError as exc:
+            print(f"  Invalid JSON in code search for '{query}': {exc}")
+            return []
+
+        # Extract unique repositories from code search results.
+        # The repository object embedded in code-search results is heavily
+        # stripped down (no stargazers_count, license, archived, or topics),
+        # so we enrich each one via /repos/{full_name}.
+        repos = []
+        repo_names_seen = set()
+
+        for item in data.get('items', []):
+            repo_data = item['repository']
+            repo_name = repo_data['full_name']
+
+            # Skip if we've already processed this repository
+            if repo_name in repo_names_seen:
+                continue
+            repo_names_seen.add(repo_name)
+
+            full = self._fetch_full_repo(repo_name)
+            if full is not None:
+                repos.append(full)
+            else:
+                # Enrichment failed; fall back to the minimal record so we at
+                # least keep the discovery hit. The failed lookup is already
+                # tracked in failed_queries and will trigger the fail-on-rate-
+                # limit guard at the end of the run.
+                repos.append({
                     'name': repo_data['name'],
                     'full_name': repo_data['full_name'],
                     'description': repo_data.get('description'),
                     'html_url': repo_data['html_url'],
-                    'stargazers_count': repo_data.get('stargazers_count', 0),
-                    'archived': repo_data.get('archived', False),
-                    'private': repo_data.get('private', False),
+                    'stargazers_count': repo_data.get('stargazers_count', 0) or 0,
+                    'archived': bool(repo_data.get('archived')),
+                    'private': bool(repo_data.get('private')),
                     'size': repo_data.get('size', 0),
                     'updated_at': repo_data.get('updated_at'),
                     'homepage': repo_data.get('homepage'),
-                    'topics': repo_data.get('topics', []),
+                    'topics': repo_data.get('topics') or [],
                     'language': repo_data.get('language'),
                     'license': repo_data.get('license'),
-                    'owner': repo_data.get('owner', {})
-                }
-                repos.append(repo)
-            
-            print(f"  Found {len(repos)} unique repositories")
-            return repos
-            
-        except Exception as e:
-            print(f"  Error in code search for '{query}': {e}")
-            return []
+                    'owner': repo_data.get('owner', {}),
+                })
+
+        print(f"  Found {len(repos)} unique repositories")
+        return repos
     
     def analyze_repository(self, repo: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Analyze a repository to extract LinkML project information."""
@@ -393,28 +594,14 @@ class GitHubSearchDiscovery:
         if contacts:
             entry['contacts'] = contacts
         
-        # Add GitHub stars for sorting
-        stars = repo.get('stargazers_count', 0)
-        if stars is None:
-            stars = 0
-        
-        # If stars is 0 or missing, try to fetch from repository API directly
-        if stars == 0 and self.token:
-            try:
-                repo_api_url = f"{self.base_url}/repos/{repo['full_name']}"
-                response = requests.get(repo_api_url, headers=self.headers)
-                if response.status_code == 200:
-                    repo_data = response.json()
-                    direct_stars = repo_data.get('stargazers_count', 0)
-                    if direct_stars > 0:
-                        stars = direct_stars
-                        print(f"  Updated {repo['full_name']} stars: {stars} (from repo API)")
-                time.sleep(1)  # Rate limiting
-            except Exception as e:
-                print(f"  Failed to fetch direct stars for {repo['full_name']}: {e}")
-        
+        # Stars: enrichment in the search phase already replaced the stripped
+        # code-search repo object with the canonical /repos/{name} response,
+        # so this is reliable. If enrichment failed for this repo, the missing
+        # data will have been recorded in failed_queries and the run will exit
+        # non-zero downstream.
+        stars = repo.get('stargazers_count') or 0
         entry['github_stars'] = stars
-        
+
         return entry
     
     def _extract_license(self, repo: Dict[str, Any]) -> str:
@@ -512,17 +699,24 @@ class GitHubSearchDiscovery:
 @click.option('--output', required=True, help='Output file for discovered registry')
 @click.option('--min-stars', default=1, help='Minimum stars required (default: 1)')
 @click.option('--analyze/--no-analyze', default=True, help='Whether to analyze repositories for metadata')
-def main(token, output, min_stars, analyze):
+@click.option('--fail-on-rate-limit/--no-fail-on-rate-limit', default=True,
+              help='Exit non-zero if any search query was dropped due to rate limits '
+                   '(default: enabled; disable for best-effort local runs)')
+def main(token, output, min_stars, analyze, fail_on_rate_limit):
     """Discover LinkML projects using GitHub Search REST API."""
-    
+
     try:
         discovery = GitHubSearchDiscovery(token)
-        
+
         print("Starting LinkML project discovery...")
         repos = discovery.search_linkml_repositories()
-        
+
         if not repos:
             print("No repositories found!")
+            if fail_on_rate_limit and discovery.failed_queries:
+                print(f"ERROR: {len(discovery.failed_queries)} queries were dropped "
+                      f"due to rate limits; refusing to publish empty result.")
+                sys.exit(2)
             return
         
         # Filter by stars
@@ -580,7 +774,14 @@ def main(token, output, min_stars, analyze):
             
             print(f"\n License distribution: {dict(sorted(licenses.items(), key=lambda x: x[1], reverse=True))}")
             print(f"\n Domain distribution: {dict(sorted(domains.items(), key=lambda x: x[1], reverse=True))}")
-        
+
+        if fail_on_rate_limit and discovery.failed_queries:
+            print(f"\nERROR: {len(discovery.failed_queries)} search queries were dropped "
+                  f"due to GitHub rate limits. The registry produced by this run is "
+                  f"likely incomplete; refusing to publish. "
+                  f"Re-run later or pass --no-fail-on-rate-limit to override.")
+            sys.exit(2)
+
     except Exception as e:
         print(f"Error: {e}")
         import traceback


### PR DESCRIPTION
Two issues here: 
- we ran into rate limiting from GH (maybe these have changed over time?)
- our automated job overwrote the registry with a truncated version because of the rate limiting and we had no checks in place to prevent this (e.g. fail the auto regeneration and notify me but keep the previously correct registry in place until we investigate the failing job). 

this PR adds some rate limiting retries and slows down this job (for up to 15 mins), and adds a 85% registry content threshold as a check for overwriting the registry.